### PR TITLE
Fixes the bower.json contributors to be an array instead of an object.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "author": "Gábor Molnár <gabor.molnar@sch.bme.hu>",
-  "contributors": { 
+  "contributors": [
     "Alan James"
-  },
+  ],
   "name": "js-schema",
   "description": "A simple and intuitive object validation library",
   "keywords": [


### PR DESCRIPTION
The `bower.json` file's contributors section was an object, but it should be an array being that there is not key before the contributors name.

Currently the contributors section being an invalid object breaks the Bower install process.
