### PR TITLE
`contributors` must be an array, not an object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "author": "Gábor Molnár <gabor.molnar@sch.bme.hu>",
-  "contributors": {
+  "contributors": [
     "Alan James"
-  },
+  ],
   "name": "js-schema",
   "description": "A simple and intuitive object validation library",
   "keywords": [


### PR DESCRIPTION
The package.json was no valid JSON. The contributors field must be an array.
