### PR TITLE
String has . as default instead of [a-zA-Z0-9]

### DIFF
--- a/lib/extensions/String.js
+++ b/lib/extensions/String.js
@@ -5,7 +5,7 @@ String.of = function() {
   //                       (length, charset)
   //                       (minLength, maxLength, charset)
   var args = Array.prototype.slice.call(arguments).reverse()
-    , charset = args[0] ? ('[' + args[0] + ']') : '[a-zA-Z0-9]'
+    , charset = args[0] ? ('[' + args[0] + ']') : '.'
     , max = args[1]
     , min = (args.length > 2) ? args[2] : args[1]
     , regexp = '^' + charset + '{' + (min || 0) + ',' + (max || '') + '}$'


### PR DESCRIPTION
Often, I don't want to restrict the charset of strings, only the minimum and maximum length. This change allows schemas to be defined with e.g. `String.of(20, 50, null)` for a string with minimum 20 characters, maximum 50 characters and non-restricted charset.
