### PR TITLE
Custom Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,14 @@ The `Array.of` method has three signatures:
 
 ### Functions ###
 
-`Function.reference(func)` matches `x` if `x === func`.
+The `Function.reference(func)` matches `x` if `x === func`.
+
+The `Function.custom(func)` takes a user-defined function and passes `x` to it. The user-defined function must return `{valid: myBooleanValue, msg: 'My fail message'}` where the `valid` field tells js-schema to pass or fail the test, and `msg` is the error message shown if `valid` is `false`. For example: 
+```javascript
+var validate = schema({
+  'name': Function.custom(x => ( { valid: x !== 'Bob' && x.length < 4, msg: 'Name is Bob or is too long' } ))
+});
+```
 
 Future plans
 ============

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = require('./lib/schema')
 
 // Patterns
+require('./lib/patterns/custom')
 require('./lib/patterns/reference')
 require('./lib/patterns/nothing')
 require('./lib/patterns/anything')

--- a/lib/extensions/Function.js
+++ b/lib/extensions/Function.js
@@ -1,5 +1,10 @@
 var ReferenceSchema = require('../patterns/reference')
+var CustomSchema = require('../patterns/custom')
 
-Function.reference = function(f) {
-  return new ReferenceSchema(f).wrap()
+Function.reference = function (f) {
+	return new ReferenceSchema(f).wrap()
+}
+
+Function.custom = function (f) {
+	return new CustomSchema(f).wrap()
 }

--- a/lib/patterns/custom.js
+++ b/lib/patterns/custom.js
@@ -1,0 +1,25 @@
+var Schema = require('../BaseSchema')
+
+var CustomSchema = module.exports = Schema.patterns.CustomSchema = Schema.extend({
+	initialize: function (func) {
+		this.func = func
+	},
+	errors: function (instance) {
+		var self = this
+		var result = self.func(instance);
+
+		if (!result.valid)
+			return result.msg
+		return false
+	},
+	validate: function (instance) {
+		return this.func(instance).valid
+	},
+	toJSON: function () {
+		return { type: 'custom' }
+	}
+})
+
+Schema.fromJS.def(function (func) {
+	return new CustomSchema(func)
+})


### PR DESCRIPTION
Solution for https://github.com/molnarg/js-schema/issues/43.

Adds support for `Function.custom()` which accepts a user-defined function and passes it the field value, expecting an object to be returned with the fields `valid` and `msg`.

```javascript
var validate = schema({
  'birthday': Function.custom(x => ( { valid: moment(x).isValid(), msg: 'Invalid datetime' } ))
});
```

Not a pure predicate because I want to allow defining an error message.